### PR TITLE
add up-to-date with main after git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Watch https://youtu.be/MnUd31TvBoU
 >>> cd C:\xampp\htdocs\
 
 >>> git clone https://github.com/ralphcajipe/BookstoreSystem.git
+```
 
+## Always stay up-to-date with the ```main``` branch
+```
 >>> git pull origin main
 ```
 


### PR DESCRIPTION
A reminder to do `git pull origin main` after doing `git clone` to stay updated with the contents of the `main` branch.